### PR TITLE
Add SiPixelCalCosmics on top of PR #28574

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_Output_cff.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+OutALCARECOSiPixelCalCosmics_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOSiPixelCalCosmics')
+    ),
+    outputCommands = cms.untracked.vstring(
+        'keep *_ALCARECOSiPixelCalCosmics_*_*',
+        'keep *_muons__*',
+        'keep *_*riggerResults_*_HLT'
+    )
+)
+import copy
+
+OutALCARECOSiPixelCalCosmics=copy.deepcopy(OutALCARECOSiPixelCalCosmics_noDrop)
+OutALCARECOSiPixelCalCosmics.outputCommands.insert(0, "drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+import copy
+
+from ALCARECOSiPixelCalSingleMuon_cff import ALCARECOSiPixelCalSingleMuonHLTFilter 
+ALCARECOSiPixelCalCosmicsHLTFilter = ALCARECOSiPixelCalSingleMuonHLTFilter.clone(
+    HLTPaths = ["HLT_*"],
+    eventSetupPathsKey = ''
+)
+
+from ALCARECOSiPixelCalSingleMuon_cff import ALCARECOSiPixelCalSingleMuon 
+ALCARECOSiPixelCalCosmics = ALCARECOSiPixelCalSingleMuon.clone(
+    ptMin = 0.0, #GeV
+    src = 'ctfWithMaterialTracksP5'
+)
+
+# Sequence #
+seqALCARECOSiPixelCalCosmics = cms.Sequence(ALCARECOSiPixelCalCosmicsHLTFilter*ALCARECOSiPixelCalCosmics)
+

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
@@ -1,6 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 import copy
 
+# DCS partitions
+# "EBp","EBm","EEp","EEm","HBHEa","HBHEb","HBHEc","HF","HO","RPC"
+# "DT0","DTp","DTm","CSCp","CSCm","CASTOR","TIBTID","TOB","TECp","TECm"
+# "BPIX","FPIX","ESp","ESm"
+import DPGAnalysis.Skims.skim_detstatus_cfi
+ALCARECOSiPixelCalCosmicsDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsstatus.clone(
+    DetectorType = cms.vstring('TIBTID','TOB','TECp','TECm','BPIX','FPIX'),
+    ApplyFilter  = cms.bool(True),
+    AndOr        = cms.bool(True),
+    DebugOn      = cms.untracked.bool(False)
+)
+
 from ALCARECOSiPixelCalSingleMuon_cff import ALCARECOSiPixelCalSingleMuonHLTFilter 
 ALCARECOSiPixelCalCosmicsHLTFilter = ALCARECOSiPixelCalSingleMuonHLTFilter.clone(
     HLTPaths = ["HLT_*"],
@@ -9,9 +21,21 @@ ALCARECOSiPixelCalCosmicsHLTFilter = ALCARECOSiPixelCalSingleMuonHLTFilter.clone
 
 from ALCARECOSiPixelCalSingleMuon_cff import ALCARECOSiPixelCalSingleMuon 
 ALCARECOSiPixelCalCosmics = ALCARECOSiPixelCalSingleMuon.clone(
-    ptMin = 0.0, #GeV
-    src = 'ctfWithMaterialTracksP5'
+    filter = True,
+    applyBasicCuts = True,
+    ptMin = 0.,
+    ptMax = 99999.,
+    pMin = 0.,
+    pMax = 99999.,
+    etaMin = -99., ##-2.4 keep also what is going through...
+    etaMax = 99., ## 2.4 ...both TEC with flat slope
+    chi2nMax = 999999.,
+    applyMultiplicityFilter = False,
+    applyNHighestPt = True, ## select only highest pT track
+    nHighestPt = 1,
+    src = 'ctfWithMaterialTracksP5',
 )
+ALCARECOSiPixelCalCosmics.minHitsPerSubDet.inPIXEL = 1
 
 # Sequence #
 seqALCARECOSiPixelCalCosmics = cms.Sequence(ALCARECOSiPixelCalCosmicsHLTFilter*ALCARECOSiPixelCalCosmics)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
@@ -7,7 +7,7 @@ import copy
 # "BPIX","FPIX","ESp","ESm"
 import DPGAnalysis.Skims.skim_detstatus_cfi
 ALCARECOSiPixelCalCosmicsDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsstatus.clone(
-    DetectorType = cms.vstring('TIBTID','TOB','TECp','TECm','BPIX','FPIX'),
+    DetectorType = cms.vstring('BPIX','FPIX'),
     ApplyFilter  = cms.bool(True),
     AndOr        = cms.bool(True),
     DebugOn      = cms.untracked.bool(False)
@@ -31,12 +31,10 @@ ALCARECOSiPixelCalCosmics = ALCARECOSiPixelCalSingleMuon.clone(
     etaMax = 99., ## 2.4 ...both TEC with flat slope
     chi2nMax = 3.,
     applyMultiplicityFilter = False,
-    applyNHighestPt = True, ## select only highest pT track
-    nHighestPt = 1,
+    applyNHighestPt = False, ## select only highest pT track
     src = 'ctfWithMaterialTracksP5',
 )
 ALCARECOSiPixelCalCosmics.minHitsPerSubDet.inPIXEL = 1
 
 # Sequence #
-seqALCARECOSiPixelCalCosmics = cms.Sequence(ALCARECOSiPixelCalCosmicsHLTFilter*ALCARECOSiPixelCalCosmics)
-
+seqALCARECOSiPixelCalCosmics = cms.Sequence(ALCARECOSiPixelCalCosmicsDCSFilter+ALCARECOSiPixelCalCosmicsHLTFilter*ALCARECOSiPixelCalCosmics)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalCosmics_cff.py
@@ -19,17 +19,17 @@ ALCARECOSiPixelCalCosmicsHLTFilter = ALCARECOSiPixelCalSingleMuonHLTFilter.clone
     eventSetupPathsKey = ''
 )
 
-from ALCARECOSiPixelCalSingleMuon_cff import ALCARECOSiPixelCalSingleMuon 
+from ALCARECOSiPixelCalSingleMuon_cff import ALCARECOSiPixelCalSingleMuon
 ALCARECOSiPixelCalCosmics = ALCARECOSiPixelCalSingleMuon.clone(
     filter = True,
     applyBasicCuts = True,
-    ptMin = 0.,
+    ptMin = 3.,
     ptMax = 99999.,
     pMin = 0.,
     pMax = 99999.,
     etaMin = -99., ##-2.4 keep also what is going through...
     etaMax = 99., ## 2.4 ...both TEC with flat slope
-    chi2nMax = 999999.,
+    chi2nMax = 3.,
     applyMultiplicityFilter = False,
     applyNHighestPt = True, ## select only highest pT track
     nHighestPt = 1,

--- a/Configuration/EventContent/python/AlCaRecoOutput_RelVal_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_RelVal_cff.py
@@ -26,6 +26,7 @@ ALCARECOEventContent = cms.PSet(
         'keep *_ALCARECOMuAlOverlaps_*_*', 
         'keep *_ALCARECOMuAlCalIsolatedMu_*_*',
         'keep *_ALCARECOSiPixelCalSingleMuon_*_*',
+        'keep *_ALCARECOSiPixelCalCosmics_*_*',
         'keep *_cosmicMuons_*_*',
         'keep *_cosmictrackfinderP5_*_*',
         'keep *_globalMuons_*_*', 

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -49,6 +49,7 @@ from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalZeroBias_Output_cff impor
 from CalibTracker.SiPixelQuality.ALCARECOSiPixelCalZeroBias_Output_cff import *
 # AlCaReco for tracker calibration using Cosmics events 
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalCosmics_Output_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOSiPixelCalCosmics_Output_cff import *
 
 # AlCaReco for tracker based alignment using beam halo
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlBeamHalo_Output_cff import *

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2421,9 +2421,9 @@ steps['ALCACOSD']={'--conditions':'auto:run1_data',
                    '-s':'ALCA:TkAlCosmics0T+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'
                    }
 
-steps['ALCACOSDRUN2']=merge([{'--conditions':'auto:run2_data','--era':'Run2_2016','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DtCalibCosmics+DQM'},steps['ALCACOSD']])
+steps['ALCACOSDRUN2']=merge([{'--conditions':'auto:run2_data','--era':'Run2_2016','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DtCalibCosmics+DQM'},steps['ALCACOSD']])
 
-steps['ALCACOSDRUN3']=merge([{'--conditions':'auto:run3_data_promptlike','--era':'Run3','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DtCalibCosmics+DQM'},steps['ALCACOSD']])
+steps['ALCACOSDRUN3']=merge([{'--conditions':'auto:run3_data_promptlike','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+MuAlGlobalCosmics+HcalCalHOCosmics+DtCalibCosmics+DQM'},steps['ALCACOSD']])
 
 steps['ALCAPROMPT']={'-s':'ALCA:PromptCalibProd',
                      '--filein':'file:TkAlMinBias.root',
@@ -2480,10 +2480,10 @@ steps['ALCABH_UP21']=merge([{'--conditions':'auto:phase1_2021_cosmics','-s':'ALC
 
 steps['ALCAHAL']=merge([{'-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},step4Up2015Defaults])
 steps['ALCACOS_UP15']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'ALCA:TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo'},step4Up2015Defaults])
-steps['ALCACOS_UP16']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2016'},step4Up2015Defaults])
-steps['ALCACOS_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2017'},step4Up2015Defaults])
-steps['ALCACOS_UP18']=merge([{'--conditions':'auto:phase1_2018_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2018'},step4Up2015Defaults])
-steps['ALCACOS_UP21']=merge([{'--conditions':'auto:phase1_2021_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run3'},step4Up2015Defaults])
+steps['ALCACOS_UP16']=merge([{'--conditions':'auto:run2_mc_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2016'},step4Up2015Defaults])
+steps['ALCACOS_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2017'},step4Up2015Defaults])
+steps['ALCACOS_UP18']=merge([{'--conditions':'auto:phase1_2018_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run2_2018'},step4Up2015Defaults])
+steps['ALCACOS_UP21']=merge([{'--conditions':'auto:phase1_2021_cosmics','-s':'ALCA:TkAlCosmics0T+SiStripCalCosmics+SiPixelCalCosmics+TkAlBeamHalo+MuAlBeamHaloOverlaps+MuAlBeamHalo','--era':'Run3'},step4Up2015Defaults])
 steps['ALCAHARVD']={'-s':'ALCAHARVEST:BeamSpotByRun+BeamSpotByLumi+SiStripQuality',
                     '--conditions':'auto:run1_data',
                     '--scenario':'pp',

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -35,6 +35,7 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBias_cff import *
 ###############################################################
 # AlCaReco for pixel calibration using muons
 from Calibration.TkAlCaRecoProducers.ALCARECOSiPixelCalSingleMuon_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOSiPixelCalCosmics_cff import *
 # AlCaReco for tracker calibration using MinBias events
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalMinBias_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalMinBiasAAG_cff import *
@@ -170,6 +171,7 @@ pathALCARECOTkAlUpsilonMuMuPA = cms.Path(seqALCARECOTkAlUpsilonMuMuPA*ALCARECOTk
 pathALCARECOTkAlMinBias = cms.Path(seqALCARECOTkAlMinBias*ALCARECOTkAlMinBiasDQM)
 pathALCARECOTkAlMinBias = cms.Path(seqALCARECOTkAlMinBias*ALCARECOTkAlMinBiasDQM)
 pathALCARECOSiPixelCalSingleMuon = cms.Path(seqALCARECOSiPixelCalSingleMuon)
+pathALCARECOSiPixelCalCosmics = cms.Path(seqALCARECOSiPixelCalCosmics)
 pathALCARECOSiStripCalMinBias = cms.Path(seqALCARECOSiStripCalMinBias*ALCARECOSiStripCalMinBiasDQM)
 pathALCARECOSiStripCalCosmics = cms.Path(seqALCARECOSiStripCalCosmics)
 pathALCARECOSiStripCalMinBiasAAG = cms.Path(seqALCARECOSiStripCalMinBiasAAG*ALCARECOSiStripCalMinBiasAAGDQM)
@@ -352,6 +354,15 @@ ALCARECOStreamSiPixelCalSingleMuon = cms.FilteredStream(
 	paths  = (pathALCARECOSiPixelCalSingleMuon),
 	content = OutALCARECOSiPixelCalSingleMuon.outputCommands,
 	selectEvents = OutALCARECOSiPixelCalSingleMuon.SelectEvents,
+	dataTier = cms.untracked.string('ALCARECO')
+	)
+
+ALCARECOStreamSiPixelCalCosmics = cms.FilteredStream(
+	responsible = 'Tamas Almos Vami',
+	name = 'SiPixelCalCosmics',
+	paths  = (pathALCARECOSiPixelCalCosmics),
+	content = OutALCARECOSiPixelCalCosmics.outputCommands,
+	selectEvents = OutALCARECOSiPixelCalCosmics.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 


### PR DESCRIPTION
tested successfully with:  `runTheMatrix.py -l 7.22,7.21,7.4,7.3 -t 4 -j 8`
and also with:
```
cmsDriver.py -s RAW2DIGI,RECO,ALCA:SiPixelCalCosmics --data --scenario cosmics --conditions 110X_dataRun2_2017_2018_Candidate_2019_11_21_04_11_05 --eventcontent=ALCARECO --datatier ALCARECO -n -1 --no_exec --era Run2_2018 --python_filename=SiPixelCalCosmics_2018_v1.py --nThreads=8 --dasquery='file dataset=/Cosmics/Commissioning2018-v1/RAW run=313084'
```