### PR TITLE
running

### DIFF
--- a/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
+++ b/DataFormats/TrackReco/interface/SiPixelTrackProbQXY.h
@@ -4,61 +4,49 @@
 #include <cstdint>
 #include <vector>
 
-namespace reco
-{
-/**
+namespace reco {
+  /**
  * Class defining the combined charge and shape probabilities for tracks that go through the SiPixel detector 
  */
-class SiPixelTrackProbQXY
-{
-public:
+  class SiPixelTrackProbQXY {
+  public:
     SiPixelTrackProbQXY() {}
 
-    SiPixelTrackProbQXY(float probQonTrack, float probXYonTrack, float probQonTrackNoL1, float probXYonTrackNoL1):
-      probQonTrack_(probQonTrack),
-      probXYonTrack_(probXYonTrack),
-      probQonTrackNoL1_(probQonTrackNoL1),
-      probXYonTrackNoL1_(probXYonTrackNoL1)
+    SiPixelTrackProbQXY(float probQonTrack, float probXYonTrack, float probQonTrackNoL1, float probXYonTrackNoL1)
+        : probQonTrack_(probQonTrack),
+          probXYonTrack_(probXYonTrack),
+          probQonTrackNoL1_(probQonTrackNoL1),
+          probXYonTrackNoL1_(probXYonTrackNoL1)
     //  m_rawDetId(rawDetId)
     {}
 
     // Return the combined charge probabilities for tracks that go through the SiPixel detector
-    float probQonTrack() const {
-        return probQonTrack_;
-    }
+    float probQonTrack() const { return probQonTrack_; }
 
     // Return the combined shape probabilities for tracks that go through the SiPixel detector
-    float probXYonTrack() const {
-        return probXYonTrack_;
-    }
+    float probXYonTrack() const { return probXYonTrack_; }
 
     // Return the combined charge probabilities for tracks that go through the SiPixel detector
     // This version now excludes layer 1 which was known to be noisy for 2017/2018
-    float probQonTrackNoL1() const {
-        return probQonTrack_;
-    }
+    float probQonTrackNoL1() const { return probQonTrack_; }
 
     // Return the combined shape probabilities for tracks that go through the SiPixel detector
     // This version now excludes layer 1 which was known to be noisy for 2017/2018
-    float probXYonTrackNoL1() const {
-        return probXYonTrackNoL1_;
-    }
+    float probXYonTrackNoL1() const { return probXYonTrackNoL1_; }
 
+    //  uint32_t rawDetId() const {
+    //      return m_rawDetId;
+    //  }
 
-  //  uint32_t rawDetId() const {
-  //      return m_rawDetId;
-  //  }
-
-private:
+  private:
     float probQonTrack_;
     float probXYonTrack_;
     float probQonTrackNoL1_;
     float probXYonTrackNoL1_;
-//    uint32_t m_rawDetId;
-};
+    //    uint32_t m_rawDetId;
+  };
 
-typedef std::vector<SiPixelTrackProbQXY> SiPixelTrackProbQXYCollection;
+  typedef std::vector<SiPixelTrackProbQXY> SiPixelTrackProbQXYCollection;
 
-} // namespace reco
+}  // namespace reco
 #endif
-

--- a/DataFormats/TrackReco/src/classes.h
+++ b/DataFormats/TrackReco/src/classes.h
@@ -1,12 +1,12 @@
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "Rtypes.h" 
-#include "Math/Cartesian3D.h" 
-#include "Math/Polar3D.h" 
-#include "Math/CylindricalEta3D.h" 
+#include "Rtypes.h"
+#include "Math/Cartesian3D.h"
+#include "Math/Polar3D.h"
+#include "Math/CylindricalEta3D.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h" 
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
-#include "DataFormats/TrackReco/interface/TrackExtraFwd.h" 
+#include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 #include "DataFormats/TrackReco/interface/TrackResiduals.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/Common/interface/AssociationVector.h"
@@ -33,4 +33,3 @@
 #include "DataFormats/TrackReco/interface/SeedStopInfo.h"
 
 #include <vector>
-

--- a/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
+++ b/RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
@@ -1,18 +1,17 @@
 // -*- C++ -*-
 //
-// Package:    SiPixelTrackProbQXYProducer 
-// Class:      SiPixelTrackProbQXYProducer 
-// 
+// Package:    SiPixelTrackProbQXYProducer
+// Class:      SiPixelTrackProbQXYProducer
+//
 /**\class SiPixelTrackProbQXYProducer  SiPixelTrackProbQXYProducer.cc RecoTracker/DeDx/plugins/SiPixelTrackProbQXYProducer.cc
 
  Description: SiPixel Charge and shape probabilities combined for tracks
 
 */
 //
-// Original Author:  Tamas Almos Vami 
+// Original Author:  Tamas Almos Vami
 //         Created:  Mon Nov 17 14:09:02 CEST 2021
 //
-
 
 // system include files
 #include <memory>
@@ -42,14 +41,14 @@
 class SiPixelTrackProbQXYProducer : public edm::stream::EDProducer<> {
 public:
   explicit SiPixelTrackProbQXYProducer(const edm::ParameterSet&);
-  ~SiPixelTrackProbQXYProducer() override;
+  ~SiPixelTrackProbQXYProducer() override = default;
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
   int factorial(int);
 
   // ----------member data ---------------------------
-  edm::EDGetTokenT<reco::TrackCollection>  trackToken_;
+  edm::EDGetTokenT<reco::TrackCollection> trackToken_;
   edm::ESHandle<TrackerGeometry> tkGeom;
 };
 
@@ -58,91 +57,79 @@ using namespace std;
 using namespace edm;
 
 SiPixelTrackProbQXYProducer::SiPixelTrackProbQXYProducer(const edm::ParameterSet& iConfig) {
-   produces<reco::SiPixelTrackProbQXYCollection >();
-   trackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
-
-   //if(!usePixel && !useStrip)
-  // edm::LogError("DeDxHitsProducer") << "No Pixel Hits NOR Strip Hits will be saved.  Running this module is useless";
+  produces<reco::SiPixelTrackProbQXYCollection>();
+  trackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
 }
 
-
-SiPixelTrackProbQXYProducer::~SiPixelTrackProbQXYProducer(){}
-
-void SiPixelTrackProbQXYProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{  
-  cout << "Running SiPixelTrackProbQXYProducer " << endl;
+void SiPixelTrackProbQXYProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
-  iEvent.getByToken(trackToken_,trackCollectionHandle);
+  iEvent.getByToken(trackToken_, trackCollectionHandle);
   const TrackCollection& trackCollection(*trackCollectionHandle.product());
   float probQonTrack = 0.0;
   float probXYonTrack = 0.0;
   // creates the output collection
   auto resultSiPixelTrackProbQXYColl = std::make_unique<reco::SiPixelTrackProbQXYCollection>();
-  
-  for(unsigned int j=0;j<trackCollection.size();j++){            
-     const reco::Track& track = trackCollection[j];
 
-     int numRecHits = 0;
-     float probQonTrackWMulti = 1;
-     float probXYonTrackWMulti = 1;
-     //auto const & trajParams = track.extra()->trajParams();
-     auto hb = track.recHitsBegin();
-     for(unsigned int h=0;h<track.recHitsSize();h++){
-        auto recHit = *(hb+h);
-        //if (!trackerHitRTTI::isFromDet(*recHit) ) continue;
-        const SiPixelRecHit* pixhit = dynamic_cast<const SiPixelRecHit*>(recHit);
-        if (pixhit->geographicalId().det() != DetId::Tracker) continue;
-        if (pixhit == nullptr) continue;
-        if (!pixhit->isValid()) continue;
-        float probQ         = pixhit->probabilityQ();
-        float probXY        = pixhit->probabilityXY();
-        numRecHits++;
-        probQonTrackWMulti *= probQ;
-        probXYonTrackWMulti *= probXY;
-     } // end looping on the rechits
+  for (unsigned int j = 0; j < trackCollection.size(); j++) {
+    const reco::Track& track = trackCollection[j];
+    int numRecHits = 0;
+    float probQonTrackWMulti = 1;
+    float probXYonTrackWMulti = 1;
+    //auto const & trajParams = track.extra()->trajParams();
+    auto hb = track.recHitsBegin();
+    for (unsigned int h = 0; h < track.recHitsSize(); h++) {
+      auto recHit = *(hb + h);
+      const SiPixelRecHit* pixhit = dynamic_cast<const SiPixelRecHit*>(recHit);
+      if (pixhit == nullptr)
+        continue;
+      if (!pixhit->isValid())
+        continue;
+      if (pixhit->geographicalId().det() != DetId::Tracker)
+        continue;
+      float probQ = pixhit->probabilityQ();
+      float probXY = pixhit->probabilityXY();
+      numRecHits++;
+      probQonTrackWMulti *= probQ;
+      probXYonTrackWMulti *= probXY;
+    }  // end looping on the rechits
 
-     float logprobQonTrackWMulti = log(probQonTrackWMulti);
-     float logprobXYonTrackWMulti = log(probXYonTrackWMulti);
-     std::cout << "numRecHits: " << numRecHits << std::endl;
-     float probQonTrackTerm = 0;
-     float probXYonTrackTerm = 0;
-     for(int iTkRh = 0; iTkRh < numRecHits; ++iTkRh) {
-        probQonTrackTerm += ((pow(-logprobQonTrackWMulti,iTkRh))/(factorial(iTkRh)));
-        probXYonTrackTerm += ((pow(-logprobXYonTrackWMulti,iTkRh))/(factorial(iTkRh)));
-        cout << "For cluster " << iTkRh << " the probQonTrackTerm is " << probQonTrackTerm << " the probXYonTrackTerm is " << probXYonTrackTerm <<  endl;
-     }
-            
-     probQonTrack = probQonTrackWMulti*probQonTrackTerm;
-     probXYonTrack = probXYonTrackWMulti*probXYonTrackTerm;
-     std::cout << "For this track probQonTrack is " << probQonTrack << " and probXYonTrack is  " << probXYonTrack << endl;
+    float logprobQonTrackWMulti = log(probQonTrackWMulti);
+    float logprobXYonTrackWMulti = log(probXYonTrackWMulti);
+    std::cout << "numRecHits: " << numRecHits << std::endl;
+    float probQonTrackTerm = 0;
+    float probXYonTrackTerm = 0;
+    for (int iTkRh = 0; iTkRh < numRecHits; ++iTkRh) {
+      probQonTrackTerm += ((pow(-logprobQonTrackWMulti, iTkRh)) / (factorial(iTkRh)));
+      probXYonTrackTerm += ((pow(-logprobXYonTrackWMulti, iTkRh)) / (factorial(iTkRh)));
+    }
 
-     //reco::SiPixelTrackProbQXY siPixelTrackProbQXY = SiPixelTrackProbQXY(probQonTrack,probXYonTrack,probQonTrack,probXYonTrack);
-     //indices.push_back(resultdedxHitColl->size());
-     //resultSiPixelTrackProbQXYColl->push_back(siPixelTrackProbQXY);
-     resultSiPixelTrackProbQXYColl->push_back(SiPixelTrackProbQXY(probQonTrack,probXYonTrack,probQonTrack,probXYonTrack));
-  } // end loop on track collection
- 
+    probQonTrack = probQonTrackWMulti * probQonTrackTerm;
+    probXYonTrack = probXYonTrackWMulti * probXYonTrackTerm;
+    //reco::SiPixelTrackProbQXY siPixelTrackProbQXY = SiPixelTrackProbQXY(probQonTrack,probXYonTrack,probQonTrack,probXYonTrack);
+    //indices.push_back(resultdedxHitColl->size());
+    //resultSiPixelTrackProbQXYColl->push_back(siPixelTrackProbQXY);
+    resultSiPixelTrackProbQXYColl->push_back(
+        SiPixelTrackProbQXY(probQonTrack, probXYonTrack, probQonTrack, probXYonTrack));
+  }  // end loop on track collection
 
-  edm::OrphanHandle<reco::SiPixelTrackProbQXYCollection> siPixelTrackProbQXYHandle = iEvent.put(std::move(resultSiPixelTrackProbQXYColl));
+  edm::OrphanHandle<reco::SiPixelTrackProbQXYCollection> siPixelTrackProbQXYHandle =
+      iEvent.put(std::move(resultSiPixelTrackProbQXYColl));
 
   //create map passing the handle to the matched collection
   //auto dedxMatch = std::make_unique<reco::DeDxHitInfoAss>(dedxHitCollHandle);
-  //reco::DeDxHitInfoAss::Filler filler(*dedxMatch);  
-  //filler.insert(trackCollectionHandle, indices.begin(), indices.end()); 
+  //reco::DeDxHitInfoAss::Filler filler(*dedxMatch);
+  //filler.insert(trackCollectionHandle, indices.begin(), indices.end());
   //filler.fill();
   //iEvent.put(std::move(dedxMatch));
 
- // auto dedxPrescale = std::make_unique<edm::ValueMap<int>>();
- // edm::ValueMap<int>::Filler pfiller(*dedxPrescale);
- // pfiller.insert(dedxHitCollHandle, prescales.begin(), prescales.end());
- // pfiller.fill();
- // iEvent.put(std::move(dedxPrescale), "prescale");
+  // auto dedxPrescale = std::make_unique<edm::ValueMap<int>>();
+  // edm::ValueMap<int>::Filler pfiller(*dedxPrescale);
+  // pfiller.insert(dedxHitCollHandle, prescales.begin(), prescales.end());
+  // pfiller.fill();
+  // iEvent.put(std::move(dedxPrescale), "prescale");
 }
 
-
-int SiPixelTrackProbQXYProducer::factorial(int n) {
-  return (n == 1 || n == 0) ? 1 : factorial(n - 1) * n;
-}
+int SiPixelTrackProbQXYProducer::factorial(int n) { return (n == 1 || n == 0) ? 1 : factorial(n - 1) * n; }
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(SiPixelTrackProbQXYProducer);


### PR DESCRIPTION
#### PR description:

now it runs.

#### PR validation:
```
cmsDriver.py  ReRECO --conditions 106X_dataRun2_v24 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018,Configuration/DataProcessing/Utils.addMonitoring --datatier RECO --era Run2_2018,pf_badHcalMitigation --eventcontent RECO --nThreads 1 --no_exec --number 10 --python_filename RAW2RECO_wNewProbQ.py --scenario pp --step RAW2DIGI,L1Reco,RECO --data  --filein root://cms-xrd-global.cern.ch//store/data/Run2018C/SingleMuon/RAW/v1/000/319/337/00000/004ED286-5582-E811-8895-FA163E126126.root
```
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
