### PR TITLE
Remove MVASelector tags for tracking in MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,13 +33,13 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v4) but with snapshot at 2022-07-12 13:00:00 (UTC)
+    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v6) but with snapshot at 2022-07-12 13:00:00 (UTC)
     'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v6',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
     'run3_hlt_relval'              : '125X_dataRun3_HLT_relval_v1',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v6 but with snapshot at 2022-10-04 14:22:26 (UTC)
+    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v8 but with snapshot at 2022-10-04 14:22:26 (UTC)
     'run3_data_express'            : '124X_dataRun3_Express_frozen_v6',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v5 but with snapshot at 2022-10-04 14:19:51 (UTC)
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v7 but with snapshot at 2022-10-04 14:19:51 (UTC)
     'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v5',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-07-12 23:00:00 (UTC)
     'run3_data'                    : '124X_dataRun3_v9',
@@ -68,21 +68,21 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '125X_mcRun3_2022_design_v2',
+    'phase1_2022_design'           : '125X_mcRun3_2022_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '125X_mcRun3_2022_realistic_v4',
+    'phase1_2022_realistic'        : '125X_mcRun3_2022_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '125X_mcRun3_2022cosmics_realistic_deco_v4',
+    'phase1_2022_cosmics'          : '125X_mcRun3_2022cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '125X_mcRun3_2022cosmics_design_deco_v2',
+    'phase1_2022_cosmics_design'   : '125X_mcRun3_2022cosmics_design_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
     'phase1_2022_realistic_hi'     : '125X_mcRun3_2022_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '125X_mcRun3_2023_realistic_v4',
+    'phase1_2023_realistic'        : '125X_mcRun3_2023_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '125X_mcRun3_2024_realistic_v4',
+    'phase1_2024_realistic'        : '125X_mcRun3_2024_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '125X_mcRun4_realistic_v3'
+    'phase2_realistic'             : '125X_mcRun4_realistic_v4'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Remove MVASelector tags for tracking as requested in https://cms-talk.web.cern.ch/t/proposal-of-removal-of-bdt-based-gbrwrapperrcd-tags-for-tracking-selection-from-run-3-globaltags/16757

This is the MC part, we expect no changes in the relval test.
I also created the data GTs but bc we need to re-snapshot I'll do another PR to integrate in CMSSW.

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_mcRun3_2022_design_v2/125X_mcRun3_2022_design_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_mcRun3_2022_realistic_v4/125X_mcRun3_2022_realistic_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_mcRun3_2022cosmics_design_deco_v2/125X_mcRun3_2022cosmics_design_deco_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_mcRun3_2023_realistic_v4/125X_mcRun3_2023_realistic_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_mcRun3_2024_realistic_v4/125X_mcRun3_2024_realistic_v5
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_mcRun4_realistic_v3/125X_mcRun4_realistic_v4

#### PR validation:

```
test parameters:
  - workflows = 12034.0,11634.0,7.23,159.0,12434.0,12834.0
 ```


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, no backport needed